### PR TITLE
FIX : missing GETPOST check parameters (none)

### DIFF
--- a/admin/externalaccess_setup.php
+++ b/admin/externalaccess_setup.php
@@ -49,7 +49,7 @@ $action = GETPOST('action', 'alpha');
 if (preg_match('/set_(.*)/',$action,$reg))
 {
 	$code=$reg[1];
-	if (dolibarr_set_const($db, $code, GETPOST($code), 'chaine', 0, '', $conf->entity) > 0)
+	if (dolibarr_set_const($db, $code, GETPOST($code, 'none'), 'chaine', 0, '', $conf->entity) > 0)
 	{
 		header("Location: ".$_SERVER["PHP_SELF"]);
 		exit;

--- a/class/actions_externalaccess.class.php
+++ b/class/actions_externalaccess.class.php
@@ -125,15 +125,15 @@ class Actionsexternalaccess
 
 		        if($context->action == 'save'){
 		            // TODO: need to check all send informations to prevent and verbose errors
-		            $user->firstname = GETPOST('firstname');
-		            $user->lastname = GETPOST('lastname');
-		            $user->address = GETPOST('address');
-		            $user->zip = GETPOST('addresszip');
-		            $user->town = GETPOST('town');
-		            $user->user_mobile = GETPOST('user_mobile');
-		            $user->office_phone = GETPOST('office_phone');
-		            $user->office_fax = GETPOST('office_fax');
-		            $user->email = GETPOST('email');
+		            $user->firstname = GETPOST('firstname', 'none');
+		            $user->lastname = GETPOST('lastname', 'none');
+		            $user->address = GETPOST('address', 'none');
+		            $user->zip = GETPOST('addresszip', 'none');
+		            $user->town = GETPOST('town', 'none');
+		            $user->user_mobile = GETPOST('user_mobile', 'none');
+		            $user->office_phone = GETPOST('office_phone', 'none');
+		            $user->office_fax = GETPOST('office_fax', 'none');
+		            $user->email = trim(GETPOST('email', 'custom', 0, FILTER_SANITIZE_EMAIL));
 
 		            if($user->update($user)>0)
 		            {
@@ -363,7 +363,7 @@ class Actionsexternalaccess
     public function print_ticketCard($ticketId = 0, $socId = 0)
     {
         print '<section id="section-ticket-card" class="type-content"><div class="container">';
-        print_ticketCard($ticketId, $socId, GETPOST('action'));
+        print_ticketCard($ticketId, $socId, GETPOST('action', 'none'));
         print '</div></section>';
     }
 
@@ -561,7 +561,7 @@ class Actionsexternalaccess
 		if(in_array($action, $newCommentActions)){
 			if ($ticket->id > 0 && checkUserTicketRight($user, $ticket, 'comment')) {
 
-				$ticket->message = GETPOST('ticket-comment');
+				$ticket->message = GETPOST('ticket-comment', 'none');
 
 				if (empty($ticket->message)) {
 					$context->setEventMessages($langs->trans('TicketCommentMissing'), 'warnings');
@@ -621,8 +621,8 @@ class Actionsexternalaccess
 				// Check
 				$errors = 0;
 
-				$ticket->message = GETPOST('message');
-				$ticket->subject = GETPOST('subject');
+				$ticket->message = GETPOST('message', 'none');
+				$ticket->subject = GETPOST('subject', 'none');
 				$ticket->fk_soc = $user->socid;
 
 				if(empty($ticket->message)){

--- a/class/actions_externalaccess.class.php
+++ b/class/actions_externalaccess.class.php
@@ -133,7 +133,7 @@ class Actionsexternalaccess
 		            $user->user_mobile = GETPOST('user_mobile', 'none');
 		            $user->office_phone = GETPOST('office_phone', 'none');
 		            $user->office_fax = GETPOST('office_fax', 'none');
-		            $user->email = trim(GETPOST('email', 'custom', 0, FILTER_SANITIZE_EMAIL));
+		            $user->email = GETPOST('email', 'custom', 0, FILTER_SANITIZE_EMAIL);
 
 		            if($user->update($user)>0)
 		            {

--- a/class/actions_externalaccess.class.php
+++ b/class/actions_externalaccess.class.php
@@ -133,7 +133,11 @@ class Actionsexternalaccess
 		            $user->user_mobile = GETPOST('user_mobile', 'none');
 		            $user->office_phone = GETPOST('office_phone', 'none');
 		            $user->office_fax = GETPOST('office_fax', 'none');
-		            $user->email = GETPOST('email', 'custom', 0, FILTER_SANITIZE_EMAIL);
+		            if(floatval(DOL_VERSION) > 4){
+		               $user->email = GETPOST('email', 'custom', 0, FILTER_SANITIZE_EMAIL);
+		            } else {
+				        $user->email = GETPOST('email', 'none');
+			        }
 
 		            if($user->update($user)>0)
 		            {

--- a/lib/ticket.lib.php
+++ b/lib/ticket.lib.php
@@ -201,7 +201,7 @@ function print_ticketCard_comment_form($ticket, $action = '', $timelineIntegrati
 
 
 	$out .= '<div class="form-group">
-				<textarea name="ticket-comment" class="form-control" id="ticket-comment" placeholder="' . $langs->transnoentities('YourCommentHere') . '" rows="10">' . dol_htmlentities(GETPOST('ticket-comment')) . '</textarea>';
+				<textarea name="ticket-comment" class="form-control" id="ticket-comment" placeholder="' . $langs->transnoentities('YourCommentHere') . '" rows="10">' . dol_htmlentities(GETPOST('ticket-comment', 'none')) . '</textarea>';
 	$out .= '</div>';
 
 	if (!empty($conf->global->FCKEDITOR_ENABLE_TICKET)){
@@ -388,7 +388,7 @@ function print_ticketCard_view($ticketId = 0, $socId = 0, $action = '')
 
 		// Sort messages
 		$sortMsg = !empty($user->conf->EA_TICKET_MSG_SORT_ORDER)?$user->conf->EA_TICKET_MSG_SORT_ORDER:'asc';
-		$getSortMsg = GETPOST('sortmsg');
+		$getSortMsg = GETPOST('sortmsg', 'none');
 		if(!empty($getSortMsg) && in_array($getSortMsg, array('asc','desc'))){
 			$sortMsg = $getSortMsg;
 			dol_set_user_param($db, $conf,$user, array('EA_TICKET_MSG_SORT_ORDER' => $sortMsg));

--- a/www/lib/login.lib.php
+++ b/www/lib/login.lib.php
@@ -28,7 +28,7 @@ function dol_loginfunction($langs,$conf,$mysoc)
     $sessiontimeout='DOLSESSTIMEOUT_'.$prefix;
     if (! empty($conf->global->MAIN_SESSION_TIMEOUT)) setcookie($sessiontimeout, $conf->global->MAIN_SESSION_TIMEOUT, 0, "/", null, false, true);
 
-    if (GETPOST('urlfrom')) $_SESSION["urlfrom"]=GETPOST('urlfrom');
+    if (GETPOST('urlfrom', 'none')) $_SESSION["urlfrom"]=GETPOST('urlfrom', 'none');
     else $_SESSION["urlfrom"] = Context::urlOrigin();
 
 

--- a/www/logout.php
+++ b/www/logout.php
@@ -37,5 +37,5 @@ dol_syslog("End of session ".$sessionname);
 unset($_SESSION['dol_login']);
 unset($_SESSION['dol_entity']);
 
-if (GETPOST('noredirect')) return;
+if (GETPOST('noredirect', 'none')) return;
 header("Location: ".$url);		// Default behaviour is redirect to index.php page

--- a/www/main.inc.php
+++ b/www/main.inc.php
@@ -716,8 +716,8 @@ if (! defined('NOLOGIN'))
 		}
 
 		// Change landing page if defined.
-		if (GETPOST('urlfrom')){
-			$landingpage = GETPOST('urlfrom');
+		if (GETPOST('urlfrom', 'none')){
+			$landingpage = GETPOST('urlfrom', 'none');
 		}
 		elseif(!empty($_SESSION["urlfrom"])){
 			$landingpage = $_SESSION["urlfrom"];

--- a/www/script/script.php
+++ b/www/script/script.php
@@ -3,7 +3,7 @@
 define('INC_FROM_SCRIPT', 1);
 require __DIR__ .'/../config.php';
 
-$action = GETPOST('action', 'none');
+$action = GETPOST('action', 'alpha');
 
 if($action === 'getlogo')
 {

--- a/www/script/script.php
+++ b/www/script/script.php
@@ -1,9 +1,9 @@
-<?php 
+<?php
 
 define('INC_FROM_SCRIPT', 1);
-require __DIR__ .'/../config.php'; 
+require __DIR__ .'/../config.php';
 
-$action = GETPOST('action');
+$action = GETPOST('action', 'none');
 
 if($action === 'getlogo')
 {
@@ -15,7 +15,7 @@ if($action === 'getlogo')
     {
         $logoFile = $conf->mycompany->dir_output.'/logos/'.$mysoc->logo;
     }
-    
+
     if(!empty($logoFile))
     {
         $type=dol_mimetype($logoFile);
@@ -29,10 +29,10 @@ if($action === 'getlogo')
             top_httphead('image/png');
             header('Content-Disposition: inline; filename="'.basename($logoFile).'"');
         }
-        
-        
+
+
         $fullpath_original_file_osencoded=dol_osencode($logoFile);
-        
+
         readfile($fullpath_original_file_osencoded);
     }
 }


### PR DESCRIPTION
# FIX

A partir de la v12 le paramètre check de la fonction GETPOST est alphanohtml par défaut ce qui fait que tous nos inputs ayant une balise html sont vidés.

Modification (et typage) de tous les paramètres check manquants.