### PR TITLE
Fix : new function name to prevent debug problems

### DIFF
--- a/class/actions_externalaccess.class.php
+++ b/class/actions_externalaccess.class.php
@@ -372,7 +372,7 @@ class Actionsexternalaccess
     public function print_ticketCard($ticketId = 0, $socId = 0)
     {
         print '<section id="section-ticket-card" class="type-content"><div class="container">';
-        print_ticketCard($ticketId, $socId, GETPOST('action', 'none'));
+        print_ticket_card($ticketId, $socId, GETPOST('action', 'none'));
         print '</div></section>';
     }
 

--- a/lib/ticket.lib.php
+++ b/lib/ticket.lib.php
@@ -81,7 +81,7 @@ function print_ticketTable($socId = 0)
 	}
 }
 
-function print_ticketCard($ticketId = 0, $socId = 0, $action = ''){
+function print_ticket_card($ticketId = 0, $socId = 0, $action = ''){
 	global $user, $langs;
 	dol_include_once('ticket/class/ticket.class.php');
 	$context = Context::getInstance();


### PR DESCRIPTION
# FIX

La fonction print_ticketCard du fichier actions_externalaccess.class.php fait appel à une fonction qui porte exactement le même nom (print_ticketCard) et qui est définie dans le fichier de lib "/custom/externalaccess/lib/ticket.lib.php"

Afin d'éviter une potentielle perte de temps si debug en nano sur serveur, je propose de renommer cette fonction de la lib en : print_ticket_card.