### PR TITLE
Retour Maintlog : ajout colonne "Méthode d'expédition" dans la liste …

### DIFF
--- a/admin/externalaccess_setup.php
+++ b/admin/externalaccess_setup.php
@@ -172,7 +172,7 @@ if(empty($conf->global->EACCESS_RGPD_MSG)){
 }
 _print_input_form_part('EACCESS_RGPD_MSG',false,'',array(),'textarea');
 
-_print_multiselect('EACCESS_LIST_ADDED_COLUMNS', false, array('ref_client'=>$langs->trans('ref_client'), 'tracking_url'=>$langs->trans('TrackingNumberOnlyExpedition')));
+_print_multiselect('EACCESS_LIST_ADDED_COLUMNS', false, array('ref_client'=>$langs->trans('ref_client'), 'tracking_number'=>$langs->trans('TrackingNumberOnlyExpedition')));
 _print_multiselect('EACCESS_LIST_ADDED_COLUMNS_SHIPPING', false, array('shipping_method_id'=>$langs->trans('shipping_method_id')));
 
 _print_title('Experimental');

--- a/admin/externalaccess_setup.php
+++ b/admin/externalaccess_setup.php
@@ -173,6 +173,7 @@ if(empty($conf->global->EACCESS_RGPD_MSG)){
 _print_input_form_part('EACCESS_RGPD_MSG',false,'',array(),'textarea');
 
 _print_multiselect('EACCESS_LIST_ADDED_COLUMNS', false, array('ref_client'=>$langs->trans('ref_client'), 'tracking_url'=>$langs->trans('TrackingNumberOnlyExpedition')));
+_print_multiselect('EACCESS_LIST_ADDED_COLUMNS_SHIPPING', false, array('shipping_method_id'=>$langs->trans('shipping_method_id')));
 
 _print_title('Experimental');
 _print_on_off('EACCESS_SET_UPLOADED_FILES_AS_PUBLIC');

--- a/langs/fr_FR/externalaccess.lang
+++ b/langs/fr_FR/externalaccess.lang
@@ -123,6 +123,7 @@ EACCESS_ACTIVATE_PROJECTS = Projets
 EACCESS_ADD_INFOS_COMMERCIAL_BAS_DE_PAGE=Afficher en bas de page les informations du commercial du tiers associé à l'utilisateur
 EACCESS_ADD_INFOS_COMMERCIAL_BAS_DE_PAGE_HELP=Il faut que la signature d'au moins un commercial du tiers associé à l'utilisateur soit remplie
 EACCESS_LIST_ADDED_COLUMNS=Colonnes supplémentaires à afficher sur les listes
+EACCESS_LIST_ADDED_COLUMNS_SHIPPING=Colonnes supplémentaires à afficher sur les listes d'expeditions
 TrackingNumberOnlyExpedition=Numéro de suivi (liste expéditions uniquement)
 ConfLinkedToContents = Paramètres liés au contenu
 ConfLinkedToContactInfos = Paramètres liés au contact
@@ -152,6 +153,7 @@ MySpace=Consulter mon espace
 ref_client=Réf. client
 ref_customer=Réf. client
 tracking_url=Numéro de suivi
+shipping_method_id=Méthode d'expédition
 
 
 ForgotThePassword=Mot de passe oublié ?

--- a/langs/fr_FR/externalaccess.lang
+++ b/langs/fr_FR/externalaccess.lang
@@ -152,7 +152,7 @@ MySpace=Consulter mon espace
 # Traductions par attribut d'objet
 ref_client=Réf. client
 ref_customer=Réf. client
-tracking_url=Numéro de suivi
+tracking_number=Numéro de suivi
 shipping_method_id=Méthode d'expédition
 
 

--- a/lib/externalaccess.lib.php
+++ b/lib/externalaccess.lib.php
@@ -715,6 +715,9 @@ function print_expeditionTable($socId = 0)
 		$TOther_fields = unserialize($conf->global->EACCESS_LIST_ADDED_COLUMNS);
 		if(empty($TOther_fields)) $TOther_fields = array();
 
+		$TOther_fields_shipping = unserialize($conf->global->EACCESS_LIST_ADDED_COLUMNS_SHIPPING);
+		if(empty($TOther_fields_shipping)) $TOther_fields_shipping = array();
+
 		print '<table id="expedition-list" class="table table-striped" >';
 
 		print '<thead>';
@@ -724,6 +727,11 @@ function print_expeditionTable($socId = 0)
 		if(!empty($TOther_fields)) {
 			foreach ($TOther_fields as $field) {
 				if($field === 'ref_client' && !isset($object->field)) $field = 'ref_customer';
+				if(property_exists('Expedition', $field)) print ' <th class="text-center" >'.$langs->trans($field).'</th>';
+			}
+		}
+		if(!empty($TOther_fields_shipping)) {
+			foreach ($TOther_fields_shipping as $field) {
 				if(property_exists('Expedition', $field)) print ' <th class="text-center" >'.$langs->trans($field).'</th>';
 			}
 		}
@@ -778,6 +786,20 @@ function print_expeditionTable($socId = 0)
 					if(property_exists('Expedition', $field)) {
 						$total_more_fields+=1;
 						print ' <td data-search="' . strip_tags($object->{$field}) . '" data-order="' . strip_tags($object->{$field}) . '" >' . $object->{$field} . '</td>';
+					}
+				}
+			}
+			if(!empty($TOther_fields_shipping)) {
+				foreach ($TOther_fields_shipping as $field) {
+					if(property_exists('Expedition', $field)) {
+						$total_more_fields+=1;
+						if($field =='shipping_method_id') {
+							$code=$langs->getLabelFromKey($db, $object->shipping_method_id, 'c_shipment_mode', 'rowid', 'code');
+							$field_label = $langs->trans("SendingMethod".strtoupper($code));
+							print ' <td data-search="' . strip_tags($field_label) . '" data-order="' . strip_tags($field_label) . '" >' . $field_label . '</td>';
+						} else {
+							print ' <td data-search="' . strip_tags($object->{$field}) . '" data-order="' . strip_tags($object->{$field}) . '" >' . $object->{$field} . '</td>';
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Ajout d'une conf qui permet de rajouter la colonne "Méthode d'expédition" seulement dans la liste des expéditions. 

J'ai ajouté une conf et ne me suis pas servi de la conf' générale d'ajout de colonnes car "Méthode d'expédition" est un champs qui existe dans une facture par exemple mais n'a pas de sens. De plus, cela donne la possibilité d'ajouter une colonne dans une liste et pas dans une autre => plus de personnalisation. 