### PR TITLE
Optimisation de code + Ajouts de colonnes dans la liste des expéditions (objets liés)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@ ___
 
 ### Added
 
-- NEW : Add column linked object in shipping list with key format linked_classname_field_fieldformat (conf EACCESS_LIST_ADDED_COLUMNS_SHIPPING) [2021-02-25]
+- NEW : Add column linked object in shipping list with key format linked-(classname)-(fieldname)-(fieldtype) (conf EACCESS_LIST_ADDED_COLUMNS_SHIPPING) [2021-02-25]
   
 - NEW : Add column "shipping method" in shipping list (conf EACCESS_LIST_ADDED_COLUMNS_SHIPPING) [2021-02-24]
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,6 +16,8 @@ ___
 
 ### Changed
 
+- FIX : Ajout de l'option "tracking_number" dans la conf EACCESS_LIST_ADDED_COLUMNS_SHIPPING plutôt que la conf EACCESS_LIST_ADDED_COLUMNS  [2021-02-24]
+
 - FIX : tracking_number and no tracking_url in shipping list [2021-02-24]
 
 - FIX : download file [2021-02-03]

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,8 @@ ___
 
 ### Added
 
+- NEW : Add column linked object in shipping list with key format linked_classname_field_fieldformat (conf EACCESS_LIST_ADDED_COLUMNS_SHIPPING) [2021-02-25]
+  
 - NEW : Add column "shipping method" in shipping list (conf EACCESS_LIST_ADDED_COLUMNS_SHIPPING) [2021-02-24]
 
 - NEW : Add public file downloader [2021-02-03]

--- a/admin/externalaccess_setup.php
+++ b/admin/externalaccess_setup.php
@@ -174,28 +174,11 @@ _print_input_form_part('EACCESS_RGPD_MSG',false,'',array(),'textarea');
 
 _print_multiselect('EACCESS_LIST_ADDED_COLUMNS', false, array('ref_client'=>$langs->trans('ref_client')));
 _print_multiselect('EACCESS_LIST_ADDED_COLUMNS_SHIPPING', false, array('shipping_method_id'=>$langs->trans('shipping_method_id'), 'tracking_number'=>$langs->trans('tracking_number')));
-_print_input_form_part('EACCESS_TOOLTIPHELP_TEXT_TRACKINGNUMBER',false,'',array('size'=> 50),'input');
 
 _print_title('Experimental');
 _print_on_off('EACCESS_SET_UPLOADED_FILES_AS_PUBLIC');
 
 print '</table>';
-
-print ' <script type="text/javascript">
-
- 			 $(document).ready(function() {
-
-						$("#EACCESS_LIST_ADDED_COLUMNS_SHIPPING :selected").each(function() {
-							if(this.value == "tracking_number"){
-								$(\'input[name="EACCESS_TOOLTIPHELP_TEXT_TRACKINGNUMBER"]\').parent().closest(\'tr\').show();
-							} else {
-								   $(\'input[name="EACCESS_TOOLTIPHELP_TEXT_TRACKINGNUMBER"]\').parent().closest(\'tr\').hide();
-							}
-						});
-			});
-
-						</script>';
-
 
 /*
  * Add setup hook

--- a/admin/externalaccess_setup.php
+++ b/admin/externalaccess_setup.php
@@ -173,7 +173,7 @@ if(empty($conf->global->EACCESS_RGPD_MSG)){
 _print_input_form_part('EACCESS_RGPD_MSG',false,'',array(),'textarea');
 
 _print_multiselect('EACCESS_LIST_ADDED_COLUMNS', false, array('ref_client'=>$langs->trans('ref_client')));
-_print_multiselect('EACCESS_LIST_ADDED_COLUMNS_SHIPPING', false, array('shipping_method_id'=>$langs->trans('shipping_method_id'), 'tracking_number'=>$langs->trans('tracking_number')));
+_print_multiselect('EACCESS_LIST_ADDED_COLUMNS_SHIPPING', false, array('shipping_method_id'=>$langs->trans('shipping_method_id'), 'tracking_number'=>$langs->trans('tracking_number'), 'linked-delivery-date_delivery-timestamp'=>$langs->trans('linked-delivery-date_delivery')));
 
 _print_title('Experimental');
 _print_on_off('EACCESS_SET_UPLOADED_FILES_AS_PUBLIC');

--- a/admin/externalaccess_setup.php
+++ b/admin/externalaccess_setup.php
@@ -173,7 +173,7 @@ if(empty($conf->global->EACCESS_RGPD_MSG)){
 _print_input_form_part('EACCESS_RGPD_MSG',false,'',array(),'textarea');
 
 _print_multiselect('EACCESS_LIST_ADDED_COLUMNS', false, array('ref_client'=>$langs->trans('ref_client')));
-_print_multiselect('EACCESS_LIST_ADDED_COLUMNS_SHIPPING', false, array('shipping_method_id'=>$langs->trans('shipping_method_id'), 'tracking_number'=>$langs->trans('tracking_number'), 'linked-delivery-date_delivery-timestamp'=>$langs->trans('linked-delivery-date_delivery')));
+_print_multiselect('EACCESS_LIST_ADDED_COLUMNS_SHIPPING', false, array('shipping_method_id'=>$langs->trans('shipping_method_id'), 'tracking_number'=>$langs->trans('tracking_number'), 'linked-delivery-date_delivery-timestamp'=>$langs->trans('linked-delivery-date_delivery-timestamp')));
 
 _print_title('Experimental');
 _print_on_off('EACCESS_SET_UPLOADED_FILES_AS_PUBLIC');

--- a/admin/externalaccess_setup.php
+++ b/admin/externalaccess_setup.php
@@ -172,13 +172,29 @@ if(empty($conf->global->EACCESS_RGPD_MSG)){
 }
 _print_input_form_part('EACCESS_RGPD_MSG',false,'',array(),'textarea');
 
-_print_multiselect('EACCESS_LIST_ADDED_COLUMNS', false, array('ref_client'=>$langs->trans('ref_client'), 'tracking_number'=>$langs->trans('TrackingNumberOnlyExpedition')));
-_print_multiselect('EACCESS_LIST_ADDED_COLUMNS_SHIPPING', false, array('shipping_method_id'=>$langs->trans('shipping_method_id')));
+_print_multiselect('EACCESS_LIST_ADDED_COLUMNS', false, array('ref_client'=>$langs->trans('ref_client')));
+_print_multiselect('EACCESS_LIST_ADDED_COLUMNS_SHIPPING', false, array('shipping_method_id'=>$langs->trans('shipping_method_id'), 'tracking_number'=>$langs->trans('tracking_number')));
+_print_input_form_part('EACCESS_TOOLTIPHELP_TEXT_TRACKINGNUMBER',false,'',array('size'=> 50),'input');
 
 _print_title('Experimental');
 _print_on_off('EACCESS_SET_UPLOADED_FILES_AS_PUBLIC');
 
 print '</table>';
+
+print ' <script type="text/javascript">
+
+ 			 $(document).ready(function() {
+
+						$("#EACCESS_LIST_ADDED_COLUMNS_SHIPPING :selected").each(function() {
+							if(this.value == "tracking_number"){
+								$(\'input[name="EACCESS_TOOLTIPHELP_TEXT_TRACKINGNUMBER"]\').parent().closest(\'tr\').show();
+							} else {
+								   $(\'input[name="EACCESS_TOOLTIPHELP_TEXT_TRACKINGNUMBER"]\').parent().closest(\'tr\').hide();
+							}
+						});
+			});
+
+						</script>';
 
 
 /*

--- a/core/modules/modexternalaccess.class.php
+++ b/core/modules/modexternalaccess.class.php
@@ -61,7 +61,7 @@ class modexternalaccess extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Ajoute un acces externe pour les clients";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.10.1';
+		$this->version = '1.11.0';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/core/modules/modexternalaccess.class.php
+++ b/core/modules/modexternalaccess.class.php
@@ -61,7 +61,7 @@ class modexternalaccess extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Ajoute un acces externe pour les clients";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.10.0';
+		$this->version = '1.10.1';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)

--- a/langs/fr_FR/externalaccess.lang
+++ b/langs/fr_FR/externalaccess.lang
@@ -153,7 +153,7 @@ ref_client=Réf. client
 ref_customer=Réf. client
 tracking_number=Numéro de suivi
 shipping_method_id=Méthode d'expédition
-
+linked-delivery-date_delivery-timestamp=Date réelle de réception
 
 ForgotThePassword=Mot de passe oublié ?
 ForgotPassword=Mot de passe oublié ?

--- a/langs/fr_FR/externalaccess.lang
+++ b/langs/fr_FR/externalaccess.lang
@@ -138,7 +138,6 @@ EACCESS_MANIFEST_ICON_HELP = Sur certains smartphones, les utilisateurs peuvent 
 EACCESS_NO_FULL_HEADBAR_FOR_HOME = Activer la vue simple sur la page d'accueil
 EACCESS_SET_UPLOADED_FILES_AS_PUBLIC = Tickets : Lors de l'ajout de pièces jointes depuis le portail, générer un lien de partage sur ces fichiers.
 EACCESS_SET_UPLOADED_FILES_AS_PUBLIC_HELP = Les documents envoyés sont ainsi consultables depuis le portail
-EACCESS_TOOLTIPHELP_TEXT_TRACKINGNUMBER = Texte info bulle du numéro de suivi
 
 # INDEX
 Quotations=Devis

--- a/langs/fr_FR/externalaccess.lang
+++ b/langs/fr_FR/externalaccess.lang
@@ -124,7 +124,6 @@ EACCESS_ADD_INFOS_COMMERCIAL_BAS_DE_PAGE=Afficher en bas de page les information
 EACCESS_ADD_INFOS_COMMERCIAL_BAS_DE_PAGE_HELP=Il faut que la signature d'au moins un commercial du tiers associé à l'utilisateur soit remplie
 EACCESS_LIST_ADDED_COLUMNS=Colonnes supplémentaires à afficher sur les listes
 EACCESS_LIST_ADDED_COLUMNS_SHIPPING=Colonnes supplémentaires à afficher sur les listes d'expeditions
-TrackingNumberOnlyExpedition=Numéro de suivi (liste expéditions uniquement)
 ConfLinkedToContents = Paramètres liés au contenu
 ConfLinkedToContactInfos = Paramètres liés au contact
 ConfLinkedToDesign = Paramètres liés à l'apparence
@@ -139,6 +138,7 @@ EACCESS_MANIFEST_ICON_HELP = Sur certains smartphones, les utilisateurs peuvent 
 EACCESS_NO_FULL_HEADBAR_FOR_HOME = Activer la vue simple sur la page d'accueil
 EACCESS_SET_UPLOADED_FILES_AS_PUBLIC = Tickets : Lors de l'ajout de pièces jointes depuis le portail, générer un lien de partage sur ces fichiers.
 EACCESS_SET_UPLOADED_FILES_AS_PUBLIC_HELP = Les documents envoyés sont ainsi consultables depuis le portail
+EACCESS_TOOLTIPHELP_TEXT_TRACKINGNUMBER = Texte info bulle du numéro de suivi
 
 # INDEX
 Quotations=Devis

--- a/lib/externalaccess.lib.php
+++ b/lib/externalaccess.lib.php
@@ -797,7 +797,10 @@ function print_expeditionTable($socId = 0)
 							$code=$langs->getLabelFromKey($db, $object->shipping_method_id, 'c_shipment_mode', 'rowid', 'code');
 							$field_label = $langs->trans("SendingMethod".strtoupper($code));
 							print ' <td data-search="' . strip_tags($field_label) . '" data-order="' . strip_tags($field_label) . '" >' . $field_label . '</td>';
-						} else {
+						} elseif ($field === 'tracking_number' && $conf->global->EACCESS_TOOLTIPHELP_TEXT_TRACKINGNUMBER) {
+							print ' <td data-search="' . strip_tags($object->{$field}) . '" data-order="' . strip_tags($object->{$field}) . '" >' . $object->{$field}.img_picto($conf->global->EACCESS_TOOLTIPHELP_TEXT_TRACKINGNUMBER, 'help') . '</td>';
+						}
+						else {
 							print ' <td data-search="' . strip_tags($object->{$field}) . '" data-order="' . strip_tags($object->{$field}) . '" >' . $object->{$field} . '</td>';
 						}
 					}

--- a/lib/externalaccess.lib.php
+++ b/lib/externalaccess.lib.php
@@ -796,9 +796,9 @@ function print_expeditionTable($socId = 0)
 						if($field =='shipping_method_id') {
 							$code = $langs->getLabelFromKey($db, $object->shipping_method_id, 'c_shipment_mode', 'rowid', 'code');
 							$field_label = $langs->trans("SendingMethod" . strtoupper($code));
-							print ' <td data-search="' . strip_tags($field_label) . '" data-order="' . strip_tags($field_label) . '" >' . $field_label . '</td>';
+							print ' <td class="'.$field.'_value" data-search="' . strip_tags($field_label) . '" data-order="' . strip_tags($field_label) . '" >' . $field_label . '</td>';
 						} else {
-							print ' <td data-search="' . strip_tags($object->{$field}) . '" data-order="' . strip_tags($object->{$field}) . '" >' . $object->{$field} . '</td>';
+							print ' <td class="'.$field.'_value" data-search="' . strip_tags($object->{$field}) . '" data-order="' . strip_tags($object->{$field}) . '" >' . $object->{$field} . '</td>';
 						}
 					}
 				}

--- a/lib/externalaccess.lib.php
+++ b/lib/externalaccess.lib.php
@@ -805,7 +805,7 @@ function print_expeditionTable($socId = 0)
 						print ' <td class="'.$field.'_value" >';
 						if(!empty($TLinkedObjects)) {
 							foreach ($TLinkedObjects as $id=>$objectlinked) {
-								if($linkedobject_field_type == 'timestamp') print date('d-m-Y', $objectlinked->{$linkedobject_field} ). ' ';
+								if($linkedobject_field_type == 'timestamp') print dol_print_date($objectlinked->{$linkedobject_field}). ' ';
 								else print $objectlinked->{$linkedobject_field} . ' ';
 							}
 						}

--- a/lib/externalaccess.lib.php
+++ b/lib/externalaccess.lib.php
@@ -794,13 +794,10 @@ function print_expeditionTable($socId = 0)
 					if(property_exists('Expedition', $field)) {
 						$total_more_fields+=1;
 						if($field =='shipping_method_id') {
-							$code=$langs->getLabelFromKey($db, $object->shipping_method_id, 'c_shipment_mode', 'rowid', 'code');
-							$field_label = $langs->trans("SendingMethod".strtoupper($code));
+							$code = $langs->getLabelFromKey($db, $object->shipping_method_id, 'c_shipment_mode', 'rowid', 'code');
+							$field_label = $langs->trans("SendingMethod" . strtoupper($code));
 							print ' <td data-search="' . strip_tags($field_label) . '" data-order="' . strip_tags($field_label) . '" >' . $field_label . '</td>';
-						} elseif ($field === 'tracking_number' && $conf->global->EACCESS_TOOLTIPHELP_TEXT_TRACKINGNUMBER) {
-							print ' <td data-search="' . strip_tags($object->{$field}) . '" data-order="' . strip_tags($object->{$field}) . '" >' . $object->{$field}.img_picto($conf->global->EACCESS_TOOLTIPHELP_TEXT_TRACKINGNUMBER, 'help') . '</td>';
-						}
-						else {
+						} else {
 							print ' <td data-search="' . strip_tags($object->{$field}) . '" data-order="' . strip_tags($object->{$field}) . '" >' . $object->{$field} . '</td>';
 						}
 					}

--- a/lib/externalaccess.lib.php
+++ b/lib/externalaccess.lib.php
@@ -712,11 +712,13 @@ function print_expeditionTable($socId = 0)
 	{
 
 
-		$TOther_fields = unserialize($conf->global->EACCESS_LIST_ADDED_COLUMNS);
-		if(empty($TOther_fields)) $TOther_fields = array();
+		$TOther_fields_all = unserialize($conf->global->EACCESS_LIST_ADDED_COLUMNS);
+		if(empty($TOther_fields_all)) $TOther_fields_all = array();
 
 		$TOther_fields_shipping = unserialize($conf->global->EACCESS_LIST_ADDED_COLUMNS_SHIPPING);
 		if(empty($TOther_fields_shipping)) $TOther_fields_shipping = array();
+
+		$TOther_fields = array_merge($TOther_fields_all, $TOther_fields_shipping);
 
 		print '<table id="expedition-list" class="table table-striped" >';
 
@@ -727,18 +729,13 @@ function print_expeditionTable($socId = 0)
 		if(!empty($TOther_fields)) {
 			foreach ($TOther_fields as $field) {
 				if($field === 'ref_client' && !isset($object->field)) $field = 'ref_customer';
-				if(property_exists('Expedition', $field)) print ' <th class="text-center" >'.$langs->trans($field).'</th>';
-			}
-		}
-		if(!empty($TOther_fields_shipping)) {
-			foreach ($TOther_fields_shipping as $field) {
-				if(property_exists('Expedition', $field)) print ' <th class="text-center" >'.$langs->trans($field).'</th>';
+				if(property_exists('Expedition', $field)) print ' <th class="'.$field.'_title text-center" >'.$langs->trans($field).'</th>';
 			}
 		}
 		print ' <th class="text-center" >'.$langs->trans('pdfLinkedDocuments').'</th>';
 		print ' <th class="text-center" >'.$langs->trans('DateLivraison').'</th>';
-		print ' <th class="text-center" >'.$langs->trans('Status').'</th>';
-		print ' <th class="text-center" ></th>';
+		print ' <th class="statut_title text-center" >'.$langs->trans('Status').'</th>';
+		print ' <th class="downloadlink_title text-center" ></th>';
 		print '</tr>';
 
 		print '</thead>';
@@ -785,29 +782,20 @@ function print_expeditionTable($socId = 0)
 					if($field === 'ref_client' && !isset($object->field)) $field = 'ref_customer';
 					if(property_exists('Expedition', $field)) {
 						$total_more_fields+=1;
-						print ' <td data-search="' . strip_tags($object->{$field}) . '" data-order="' . strip_tags($object->{$field}) . '" >' . $object->{$field} . '</td>';
-					}
-				}
-			}
-			if(!empty($TOther_fields_shipping)) {
-				foreach ($TOther_fields_shipping as $field) {
-					if(property_exists('Expedition', $field)) {
-						$total_more_fields+=1;
 						if($field =='shipping_method_id') {
 							$code = $langs->getLabelFromKey($db, $object->shipping_method_id, 'c_shipment_mode', 'rowid', 'code');
 							$field_label = $langs->trans("SendingMethod" . strtoupper($code));
 							print ' <td class="'.$field.'_value" data-search="' . strip_tags($field_label) . '" data-order="' . strip_tags($field_label) . '" >' . $field_label . '</td>';
 						} else {
 							print ' <td class="'.$field.'_value" data-search="' . strip_tags($object->{$field}) . '" data-order="' . strip_tags($object->{$field}) . '" >' . $object->{$field} . '</td>';
-						}
-					}
+						}					}
 				}
 			}
 			print ' <td data-search="'.$reftosearch.'" data-order="'.$reftosearch.'"  >'.$reftoshow.'</td>';
 			print ' <td data-search="'.dol_print_date($object->date_delivery).'" data-order="'.$object->date_delivery.'" >'.dol_print_date($object->date_delivery).'</td>';
-			print ' <td class="text-center" >'.$object->getLibStatut(0).'</td>';
+			print ' <td class="statut_value text-center" >'.$object->getLibStatut(0).'</td>';
 
-			print ' <td class="text-right" >'.$downloadLink.'</td>';
+			print ' <td class="downloadlink_value text-right" >'.$downloadLink.'</td>';
 
 
 			print '</tr>';

--- a/lib/externalaccess.lib.php
+++ b/lib/externalaccess.lib.php
@@ -732,7 +732,7 @@ function print_expeditionTable($socId = 0)
 				if(property_exists('Expedition', $field)) print ' <th class="'.$field.'_title text-center" >'.$langs->trans($field).'</th>';
 			}
 		}
-		print ' <th class="text-center" >'.$langs->trans('pdfLinkedDocuments').'</th>';
+		print ' <th class="reftoshow_title text-center" >'.$langs->trans('pdfLinkedDocuments').'</th>';
 		print ' <th class="text-center" >'.$langs->trans('DateLivraison').'</th>';
 		print ' <th class="statut_title text-center" >'.$langs->trans('Status').'</th>';
 		print ' <th class="downloadlink_title text-center" ></th>';
@@ -791,7 +791,7 @@ function print_expeditionTable($socId = 0)
 						}					}
 				}
 			}
-			print ' <td data-search="'.$reftosearch.'" data-order="'.$reftosearch.'"  >'.$reftoshow.'</td>';
+			print ' <td class="reftoshow_value data-search="'.$reftosearch.'" data-order="'.$reftosearch.'"  >'.$reftoshow.'</td>';
 			print ' <td data-search="'.dol_print_date($object->date_delivery).'" data-order="'.$object->date_delivery.'" >'.dol_print_date($object->date_delivery).'</td>';
 			print ' <td class="statut_value text-center" >'.$object->getLibStatut(0).'</td>';
 


### PR DESCRIPTION
# FIX Optimisation de code + Ajouts de colonnes dans la liste des expéditions (objets liés)

- Optimisation du code avec ajout de nom de classe pour le js du climaintlog
- Option "tracking_number" dans la conf des colonnes de la liste expédition plutôt que dans la conf générale
- Ajout de colonnes de champs d'objets liés dans la liste des expéditions au format linked-[class name]-[field name]-[field type]