### PR TITLE
New function load last main doc multientity

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ TODO : pour les options commencer à voir si possible de crééer des tab par el
 
 ## Unreleased
 
+- NEW : Ajout fonction load_last_main_doc_multientity qui est la même que load_last_main-doc mais compatible multi-company en version > 12 - *1.29.0* - **24/11/2021**
 - NEW : Ajout type checkbox dans la fonction "stdFormHelper" - *1.28.0* - **03/11/2021**
 - NEW : ajout hook "printFieldListValue" et "printFieldListTitle" dans la liste des propals - *03/11/2021* - 1.27.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,7 +7,7 @@ TODO : pour les options commencer à voir si possible de crééer des tab par el
 
 ## Unreleased
 
-- NEW : Ajout fonction load_last_main_doc_multientity qui est la même que load_last_main-doc mais compatible multi-company en version > 12 - *1.29.0* - **24/11/2021**
+- NEW : Ajout fonction load_last_main_doc : ajout gestion multientité - *1.29.0* - **24/11/2021**
 - NEW : Ajout type checkbox dans la fonction "stdFormHelper" - *1.28.0* - **03/11/2021**
 - NEW : ajout hook "printFieldListValue" et "printFieldListTitle" dans la liste des propals - *03/11/2021* - 1.27.0
 

--- a/class/actions_externalaccess.class.php
+++ b/class/actions_externalaccess.class.php
@@ -244,8 +244,8 @@ class Actionsexternalaccess
                     if (!empty($conf->global->EACCESS_RESET_LASTMAINDOC_BEFORE_DOWNLOAD_PROPAL)){
                         $object->last_main_doc = '';
                     }
-                    load_last_main_doc_multientity($object);
-                    $filename = $object->last_main_doc;
+                    load_last_main_doc($object);
+                    $filename = DOL_DATA_ROOT.'/'.$object->last_main_doc;
 
 	                if(!empty($object->last_main_doc)){
 	                    downloadFile($filename, $forceDownload);

--- a/class/actions_externalaccess.class.php
+++ b/class/actions_externalaccess.class.php
@@ -244,8 +244,8 @@ class Actionsexternalaccess
                     if (!empty($conf->global->EACCESS_RESET_LASTMAINDOC_BEFORE_DOWNLOAD_PROPAL)){
                         $object->last_main_doc = '';
                     }
-                    load_last_main_doc($object);
-                    $filename = DOL_DATA_ROOT.'/'.$object->last_main_doc;
+                    load_last_main_doc_multientity($object);
+                    $filename = $object->last_main_doc;
 
 	                if(!empty($object->last_main_doc)){
 	                    downloadFile($filename, $forceDownload);

--- a/core/modules/modexternalaccess.class.php
+++ b/core/modules/modexternalaccess.class.php
@@ -64,7 +64,7 @@ class modexternalaccess extends DolibarrModules
 
 
 
-		$this->version = '1.28.0';
+		$this->version = '1.29.0';
 
 
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)

--- a/lib/externalaccess.lib.php
+++ b/lib/externalaccess.lib.php
@@ -903,3 +903,27 @@ function load_last_main_doc(&$object) {
 	}
 
 }
+
+/*
+ * Compatible à partir de la version V12
+ */
+
+function load_last_main_doc_multientity(&$object) {
+
+	global $conf;
+
+	if(empty($object->last_main_doc)) {
+		$ref = dol_sanitizeFileName($object->ref);
+
+		$last_main_doc = $conf->{$object->element}->multidir_output[$object->entity].'/'.$ref.'/'.$ref.'.pdf';
+
+		if($object->element == 'propal'){
+			$last_main_doc = $conf->propal->multidir_output[$object->entity].'/'.$ref.'/'.$ref.'.pdf';
+		}
+		elseif($object->element == 'shipping'){
+			$last_main_doc = $conf->expedition->multidir_output[$object->entity].'/'.$ref.'/'.$ref.'.pdf';
+		}
+
+		if(is_readable($last_main_doc) && is_file ($last_main_doc)) $object->last_main_doc = $last_main_doc;
+	}
+}

--- a/lib/externalaccess.lib.php
+++ b/lib/externalaccess.lib.php
@@ -890,43 +890,34 @@ function load_last_main_doc(&$object) {
 
 	if(empty($object->last_main_doc)) {
 		$ref = dol_sanitizeFileName($object->ref);
-		$last_main_doc = $object->element.'/'.$ref.'/'.$ref.'.pdf';
 
-		if($object->element == 'propal'){
-			$last_main_doc = 'propale/'.$ref.'/'.$ref.'.pdf';
-        }
-		elseif($object->element == 'shipping'){
-            $last_main_doc =  'expedition/sending/'.$ref.'/'.$ref.'.pdf';
-        }
+		// compatible version < 12
+		if(version_compare(DOL_VERSION, '12.0', '<')) {
 
-		if(is_readable(DOL_DATA_ROOT.'/'.$last_main_doc) && is_file ( DOL_DATA_ROOT.'/'.$last_main_doc )) $object->last_main_doc = $last_main_doc;
+			$last_main_doc = $object->element . '/' . $ref . '/' . $ref . '.pdf';
+
+			if ($object->element == 'propal') {
+				$last_main_doc = 'propale/' . $ref . '/' . $ref . '.pdf';
+			} elseif ($object->element == 'shipping') {
+				$last_main_doc = 'expedition/sending/' . $ref . '/' . $ref . '.pdf';
+			}
+
+			if (is_readable(DOL_DATA_ROOT . '/' . $last_main_doc) && is_file(DOL_DATA_ROOT . '/' . $last_main_doc)) $object->last_main_doc = $last_main_doc;
+		}
+		// compatible version >= 12
+		else {
+
+			$last_main_doc = $conf->{$object->element}->multidir_output[$object->entity].'/'.$ref.'/'.$ref.'.pdf';
+
+			if($object->element == 'propal'){
+				$last_main_doc = $conf->propal->multidir_output[$object->entity].'/'.$ref.'/'.$ref.'.pdf';
+			}
+			elseif($object->element == 'shipping'){
+				$last_main_doc = $conf->expedition->multidir_output[$object->entity].'/'.$ref.'/'.$ref.'.pdf';
+			}
+
+			if(is_readable($last_main_doc) && is_file ($last_main_doc)) $object->last_main_doc = str_replace(DOL_DATA_ROOT,'',$last_main_doc);
+		}
 	}
 
-}
-
-/*
- * Compatible toute version, retourne le chemin entier
- */
-
-function load_last_main_doc_multientity(&$object) {
-
-	global $conf;
-
-	if(empty($object->last_main_doc)) {
-		$ref = dol_sanitizeFileName($object->ref);
-
-		if(DOL_VERSION < 12) $last_main_doc = DOL_DATA_ROOT.'/'.$object->element.'/'.$ref.'/'.$ref.'.pdf';
-		else $last_main_doc = $conf->{$object->element}->multidir_output[$object->entity].'/'.$ref.'/'.$ref.'.pdf';
-
-		if($object->element == 'propal'){
-			if(DOL_VERSION < 12) $last_main_doc = DOL_DATA_ROOT.'/propale/'.$ref.'/'.$ref.'.pdf';
-			else $last_main_doc = $conf->propal->multidir_output[$object->entity].'/'.$ref.'/'.$ref.'.pdf';
-		}
-		elseif($object->element == 'shipping'){
-			if(DOL_VERSION < 12)  $last_main_doc = DOL_DATA_ROOT.'/expedition/sending/'.$ref.'/'.$ref.'.pdf';
-			$last_main_doc = $conf->expedition->multidir_output[$object->entity].'/'.$ref.'/'.$ref.'.pdf';
-		}
-
-		if(is_readable($last_main_doc) && is_file ($last_main_doc)) $object->last_main_doc = $last_main_doc;
-	}
 }

--- a/lib/externalaccess.lib.php
+++ b/lib/externalaccess.lib.php
@@ -905,7 +905,7 @@ function load_last_main_doc(&$object) {
 }
 
 /*
- * Compatible à partir de la version V12
+ * Compatible toute version, retourne le chemin entier
  */
 
 function load_last_main_doc_multientity(&$object) {
@@ -915,12 +915,15 @@ function load_last_main_doc_multientity(&$object) {
 	if(empty($object->last_main_doc)) {
 		$ref = dol_sanitizeFileName($object->ref);
 
-		$last_main_doc = $conf->{$object->element}->multidir_output[$object->entity].'/'.$ref.'/'.$ref.'.pdf';
+		if(DOL_VERSION < 12) $last_main_doc = DOL_DATA_ROOT.'/'.$object->element.'/'.$ref.'/'.$ref.'.pdf';
+		else $last_main_doc = $conf->{$object->element}->multidir_output[$object->entity].'/'.$ref.'/'.$ref.'.pdf';
 
 		if($object->element == 'propal'){
-			$last_main_doc = $conf->propal->multidir_output[$object->entity].'/'.$ref.'/'.$ref.'.pdf';
+			if(DOL_VERSION < 12) $last_main_doc = DOL_DATA_ROOT.'/propale/'.$ref.'/'.$ref.'.pdf';
+			else $last_main_doc = $conf->propal->multidir_output[$object->entity].'/'.$ref.'/'.$ref.'.pdf';
 		}
 		elseif($object->element == 'shipping'){
+			if(DOL_VERSION < 12)  $last_main_doc = DOL_DATA_ROOT.'/expedition/sending/'.$ref.'/'.$ref.'.pdf';
 			$last_main_doc = $conf->expedition->multidir_output[$object->entity].'/'.$ref.'/'.$ref.'.pdf';
 		}
 


### PR DESCRIPTION
Ajoute une fonction load_last_main_doc qui gère le multi entité : retourne le chemin entier au lieu du chemin partiel de la fonction de base => c'est pourquoi j'ai créé une nouvelle fonction car ce bout de code est utilisé à beaucoup d'endroit.