### PR TITLE
fix: render readonly checkbox on all browser

### DIFF
--- a/lib/externalaccess.lib.php
+++ b/lib/externalaccess.lib.php
@@ -335,7 +335,7 @@ function stdFormHelper($name='', $label='', $value = '', $mode = 'edit', $htmlen
 		}
 		print '</select>';
 	} elseif ($param['type'] == 'checkbox') {
-		print '<input id="'.$name.'" name="'.$name.'" type="'.$param['type'].'" '.$readonly.' class="'.$class.'"';
+		print '<input id="'.$name.'" name="'.$name.'" type="'.$param['type'].'" '.$readonly.(!empty($readonly)?' disabled ':'').' class="'.$class.'"';
 		if(!empty($param['required'])){
 			print ' required ';
 		}


### PR DESCRIPTION
With most browser for a checkbox "readonly" attribute is not enough, you have to add "disabled" attribute