### PR TITLE
FIX : DA025305 - Extrafields tickets non-affichés 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@ TODO : pour les options commencer à voir si possible de crééer des tab par el
 
 # RELEASE 1.44
 
+- FIX : Extrafields non-affichait pour la partie tickets - 1.44.2 - **14/08/2024**
 - FIX : Compat V20 - 1.44.1 - **17/07/2024**
 - FIX : Missing tech atm class - 1.44.0 - **26/06/2024**
 - NEW : Ajout d'un champ "Email pour suivi ticket" + sévérité selon conf - 1.44.0 - **10/06/2024**

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,7 +11,7 @@ TODO : pour les options commencer à voir si possible de crééer des tab par el
 
 # RELEASE 1.44
 
-- FIX : Extrafields non-affichait pour la partie tickets - 1.44.2 - **14/08/2024**
+- FIX : Extrafields non-affichés pour la partie tickets - 1.44.2 - **14/08/2024**
 - FIX : Compat V20 - 1.44.1 - **17/07/2024**
 - FIX : Missing tech atm class - 1.44.0 - **26/06/2024**
 - NEW : Ajout d'un champ "Email pour suivi ticket" + sévérité selon conf - 1.44.0 - **10/06/2024**

--- a/core/modules/modExternalAccess.class.php
+++ b/core/modules/modExternalAccess.class.php
@@ -62,7 +62,7 @@ class modExternalAccess extends DolibarrModules
 		$this->description = "Ajoute un acces externe pour les clients";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '1.44.1';
+		$this->version = '1.44.2';
 
 		require_once __DIR__ . '/../../class/techatm.class.php';
 		$this->url_last_version = \externalaccess\TechATM::getLastModuleVersionUrl($this);

--- a/lib/ticket.lib.php
+++ b/lib/ticket.lib.php
@@ -669,7 +669,7 @@ function print_ticketCard_extrafields($ticket) {
 	$out = '';
 	$e = new ExtraFields($db);
 	$e->fetch_name_optionals_label('ticket');
-	$TTicketAddedField = unserialize(getDolGlobalString('EACCESS_CARD_ADDED_FIELD_TICKET'));
+	$TTicketAddedField = explode(',', getDolGlobalString('EACCESS_CARD_ADDED_FIELD_TICKET'));
 	if(! empty($TTicketAddedField)) {
 		foreach($TTicketAddedField as $ticket_field) {
 			$ticket_field = strtr($ticket_field, array('EXTRAFIELD_' => ''));
@@ -1327,7 +1327,7 @@ function externalAccessGetTicketEcmList($object, $pulicOnly = true)
 function addTicketContact(Ticket $ticket, array $TResults, Context $context): int
 {
 	global $langs;
-	
+
 	foreach($TResults as $obj){
 		$fk_socpeople = intval($obj->rowid);
 		$resAddContact = $ticket->add_contact($fk_socpeople, 'SUPPORTCLI');
@@ -1337,7 +1337,7 @@ function addTicketContact(Ticket $ticket, array $TResults, Context $context): in
 			return -1;
 		}
 	}
-	
+
 	return 1;
 }
 

--- a/www/controllers/tickets.controller.php
+++ b/www/controllers/tickets.controller.php
@@ -97,10 +97,10 @@ class TicketsController extends Controller
 		if(!empty($tableItems))
 		{
 
-			$TOther_fields = unserialize(getDolGlobalString('EACCESS_LIST_ADDED_COLUMNS'));
+			$TOther_fields = explode(',', getDolGlobalString('EACCESS_LIST_ADDED_COLUMNS'));
 			if(empty($TOther_fields)) $TOther_fields = array();
 
-			$TOther_fields_ticket = unserialize(getDolGlobalString('EACCESS_LIST_ADDED_COLUMNS_TICKET'));
+			$TOther_fields_ticket = explode(',', getDolGlobalString('EACCESS_LIST_ADDED_COLUMNS_TICKET'));
 			if(empty($TOther_fields_ticket)) $TOther_fields_ticket = array();
 
 			$TOther_fields = array_merge($TOther_fields, $TOther_fields_ticket);


### PR DESCRIPTION
## FIX : DA025305 - Extrafields tickets non-affichés 

Les extrafields de tickets n'étaient pas affichés sur les cards/listes d'externalaccess 
C'était dû à la présence de la fonction unserialized utilisée à la place de la fonction explode. 
