### PR TITLE
Missing require extrafield class during init

### DIFF
--- a/core/modules/modExternalAccess.class.php
+++ b/core/modules/modExternalAccess.class.php
@@ -385,6 +385,7 @@ class modExternalAccess extends DolibarrModules
 
 		define('INC_FROM_DOLIBARR', true);
 
+		require_once DOL_DOCUMENT_ROOT . '/core/class/extrafields.class.php';
 		$extrafields = new ExtraFields($this->db);
 		$extrafields->addExtraField(
 			'externalaccess_followupemail',


### PR DESCRIPTION
PHP Fatal error:  Uncaught Error: Class "ExtraFields" not found in /var/www/doliprod/htdocs/custom/externalaccess/core/modules/modExternalAccess.class.php:388
Stack trace:
#0 /var/www/doliprod/htdocs/core/lib/admin.lib.php(1181): modExternalAccess->init()
#1 Standard input code(10): activateModule()
#2 {main}
  thrown in /var/www/doliprod/htdocs/custom/externalaccess/core/modules/modExternalAccess.class.php on line 388